### PR TITLE
Bump up minimum php version from 7.3 to 7.4. use typed properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 7.3
   - 7.4
   - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.8",
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "phpunit/phpunit": "^9.0"
+        "friendsofphp/php-cs-fixer": "^2.17",
+        "phpunit/phpunit": "^9.5"
     },
     "config": {
         "sort-packages": true

--- a/src/Coverage/TestLocation.php
+++ b/src/Coverage/TestLocation.php
@@ -37,9 +37,9 @@ namespace Infection\AbstractTestFramework\Coverage;
 
 final class TestLocation
 {
-    private $method;
-    private $filePath;
-    private $executionTime;
+    private string $method;
+    private ?string $filePath;
+    private ?float $executionTime;
 
     public function __construct(string $method, ?string $filePath, ?float $executionTime)
     {

--- a/src/UnsupportedTestFrameworkVersion.php
+++ b/src/UnsupportedTestFrameworkVersion.php
@@ -39,12 +39,12 @@ use RuntimeException;
 
 final class UnsupportedTestFrameworkVersion extends RuntimeException
 {
-    private $detectedVersion;
-    private $minimumSupportedVersion;
+    private string $detectedVersion;
+    private string $minimumSupportedVersion;
 
     public function __construct(string $detectedVersion, string $minimumSupportedVersion)
     {
-        parent::__construct('', 0, null);
+        parent::__construct();
 
         $this->detectedVersion = $detectedVersion;
         $this->minimumSupportedVersion = $minimumSupportedVersion;


### PR DESCRIPTION
Bump up minimum php version from 7.3 to 7.4 and use typed properties

Please keep an eye that we need to release **0.5** version because we have an issue that 0.3.1 supports php 7.3 and php 8.0 but 0.4 supports just php 7.3