### PR TITLE
build: Allow the ergebnis/composer-normalize plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
     }
 }


### PR DESCRIPTION
At the time the plugin was added, Composer probably did not have the plugin permission check in place.