### PR TITLE
chore: Bump PHP minimum requirements to PHP 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.3', '8.4', '8.5']
 
     name: CI with PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4']
+        php-version: ['8.3']
 
     name: Coding Standards on PHP ${{ matrix.php-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.3"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.18",


### PR DESCRIPTION
This PR aligns the PHP minimum requirements with the rest of the infection packages.