### PR TITLE
build: Introduce a Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,5 +51,4 @@ jobs:
           composer install --no-interaction --no-progress --no-suggest --prefer-dist
 
       - name: Run tests
-        run: |
-          make test-unit
+        run: make test-unit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Run tests
         run: |
-          vendor/bin/phpunit
+          make test-unit

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -47,10 +47,6 @@ jobs:
         run: |
           composer install --no-interaction --no-progress --no-suggest --prefer-dist
 
-      - name: Run PHP-CS-Fixer
+      - name: Run coding standard checks
         run: |
-          vendor/bin/php-cs-fixer fix --diff --dry-run --verbose
-
-      - name: Run Composer Normalize
-        run: |
-          composer normalize --no-check-lock --diff --dry-run
+          make cs-lint

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -48,5 +48,4 @@ jobs:
           composer install --no-interaction --no-progress --no-suggest --prefer-dist
 
       - name: Run coding standard checks
-        run: |
-          make cs-lint
+        run: make cs-lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# See https://tech.davis-hansson.com/p/make/
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@printf "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n\n"
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
+
+.PHONY: check
+check:		## Runs all checks
+check: cs-lint test-unit
+
+.PHONY: cs
+cs:		## Applies coding standard fixes
+cs: vendor/autoload.php
+	vendor/bin/php-cs-fixer fix --diff --verbose
+	composer normalize --no-check-lock --diff
+
+.PHONY: cs-lint
+cs-lint:	## Runs coding standard checks
+cs-lint: vendor/autoload.php
+	vendor/bin/php-cs-fixer fix --diff --dry-run --verbose
+	composer normalize --no-check-lock --diff --dry-run
+	composer validate --strict
+
+.PHONY: test-unit
+test-unit:	## Runs the unit tests
+test-unit: vendor/autoload.php
+	vendor/bin/phpunit
+
+vendor/autoload.php:
+	composer install --prefer-dist
+	touch -c $@

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.18",
+        "fidry/makefile": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "phpunit/phpunit": "^9.5"
     },
@@ -28,9 +29,9 @@
         }
     },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "ergebnis/composer-normalize": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/tests/MakefileTest.php
+++ b/tests/MakefileTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, 2019 Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\AbstractTestFramework;
+
+use Fidry\Makefile\Test\BaseMakefileTestCase;
+
+final class MakefileTest extends BaseMakefileTestCase
+{
+    protected static function getMakefilePath(): string
+    {
+        return __DIR__ . '/../Makefile';
+    }
+
+    protected function getExpectedHelpOutput(): string
+    {
+        return "\033[33mUsage:\033[0m\n"
+            . "  make TARGET\n"
+            . "\n"
+            . "\033[32m#\n"
+            . "# Commands\n"
+            . "#---------------------------------------------------------------------------\033[0m\n"
+            . "\n"
+            . "\033[33mcheck:\033[0m\t\t Runs all checks\n"
+            . "\033[33mcs:\033[0m\t\t Applies coding standard fixes\n"
+            . "\033[33mcs-lint:\033[0m\t Runs coding standard checks\n"
+            . "\033[33mtest-unit:\033[0m\t Runs the unit tests\n";
+    }
+}


### PR DESCRIPTION
This PR aligns the Makefile usage we have in the other infection projects. It:

- Introduces a minimal `Makefile` file.
- Leverages the make commands in the GitHub Action workflows.
- Introduces a minimal test to test the Makefile via `fidry/makefile`.