### PR TITLE
cs: Update PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+!/var/.gitkeep
 /.composer/
 /.idea
 /.php-cs-fixer.cache
 /composer.lock
+/var/*
 /vendor/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -31,17 +31,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
-$header = trim(sprintf(
+$header = \trim(\sprintf(
     'This code is licensed under the BSD 3-Clause License.%s',
-    substr(
-        file_get_contents(__DIR__ . '/LICENSE'),
-        strlen('BSD 3-Clause License')
-    )
+    \substr(
+        \file_get_contents(__DIR__ . '/LICENSE'),
+        \strlen('BSD 3-Clause License'),
+    ),
 ));
 
 $finder = Finder::create()
@@ -49,29 +48,36 @@ $finder = Finder::create()
     ->exclude([
         '.github',
         'docs',
+        'var',
     ])
     ->ignoreDotFiles(false)
     ->name('*php')
-    ->append([__FILE__])
+    ->append([
+        __FILE__,
+    ])
 ;
 
 return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHPUnit60Migration:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP7x1Migration' => true,
+        '@PHP7x1Migration:risky' => true,
+        '@PHPUnit6x0Migration:risky' => true,
+        '@PHPUnit7x5Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
+        'array_indentation' => true,
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
                 'continue',
                 'declare',
                 'do',
+                'exit',
                 'for',
                 'foreach',
+                'goto',
                 'if',
                 'include',
                 'include_once',
@@ -83,11 +89,18 @@ return (new Config())
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
-        'compact_nullable_typehint' => true,
+        'blank_line_between_import_groups' => false,
+        'compact_nullable_type_declaration' => true,
         'concat_space' => ['spacing' => 'one'],
-        'fully_qualified_strict_types' => true,
+        'class_attributes_separation' => true,
+        'fully_qualified_strict_types' => [
+            'import_symbols' => true,
+        ],
+        // TODO: enable
+        'get_class_to_class_keyword' => false,
         'global_namespace_import' => [
             'import_classes' => true,
             'import_constants' => true,
@@ -103,29 +116,38 @@ return (new Config())
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'native_constant_invocation' => false,
-        'native_function_invocation' => false,
+        'modernize_strpos' => true,
+        'native_constant_invocation' => true,
+        'native_function_invocation' => [
+            'include' => ['@internal'],
+        ],
         'no_alternative_syntax' => true,
         'no_superfluous_phpdoc_tags' => true,
+        'no_trailing_whitespace_in_string' => false,
         'no_unset_cast' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'nullable_type_declaration_for_default_null_value' => true,
+        'operator_linebreak' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'ordered_interfaces' => true,
         'phpdoc_align' => [
             'align' => 'left',
         ],
-        'phpdoc_order_by_value' => [
-            'annotations' => ['covers'],
-        ],
+        // This rule is buggy and does not only apply to phpdoc annotation...
+        'phpdoc_annotation_without_dot' => false,
+        // Allow inline static analysis suppress statements
+        'phpdoc_to_comment' => false,
         'php_unit_dedicate_assert' => true,
         'php_unit_method_casing' => [
             'case' => 'snake_case',
         ],
         'php_unit_set_up_tear_down_visibility' => true,
-        'php_unit_strict' => true,
+        'php_unit_strict' => false,
+        'phpdoc_order_by_value' => [
+            'annotations' => ['covers'],
+        ],
         'php_unit_test_annotation' => [
             'style' => 'prefix',
         ],
@@ -135,15 +157,24 @@ return (new Config())
         'phpdoc_no_empty_return' => true,
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
+        'phpdoc_separation' => false,
+        'heredoc_indentation' => true,
         'self_static_accessor' => true,
         'single_line_throw' => false,
         'static_lambda' => true,
         'strict_comparison' => true,
+        'strict_param' => true,
+        'trailing_comma_in_multiline' => [
+            'after_heredoc' => true,
+            'elements' => ['arguments', 'arrays', 'match', 'parameters'],
+        ],
         'yoda_style' => [
             'equal' => false,
             'identical' => false,
             'less_and_greater' => false,
         ],
+        'blank_line_after_opening_tag' => false,
     ])
     ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/var/cache/php-cs-fixer')
 ;

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ check: cs-lint test-unit zizmor
 
 .PHONY: cs
 cs:		## Applies coding standard fixes
-cs: composer-normalize gitsortignore vendor/autoload.php
-	$(PHP_CS_FIXER) fix --diff --verbose
+cs: composer-normalize gitsortignore php-cs-fixer
 
 .PHONY: composer-normalize
 # Normalizes composer.json
@@ -34,7 +33,16 @@ gitsortignore:
 
 .PHONY: cs-lint
 cs-lint:	## Runs coding standard checks
-cs-lint: composer-normalize-lint composer-validate vendor/autoload.php
+cs-lint: composer-normalize-lint composer-validate php-cs-fixer-lint
+
+.PHONY: php-cs-fixer
+# Applies PHP-CS-Fixer fixes
+php-cs-fixer: vendor/autoload.php
+	$(PHP_CS_FIXER) fix --diff --verbose
+
+.PHONY: php-cs-fixer-lint
+# Checks PHP-CS-Fixer rules
+php-cs-fixer-lint: vendor/autoload.php
 	$(PHP_CS_FIXER) fix --diff --dry-run --verbose
 
 .PHONY: composer-normalize-lint

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.18",
         "fidry/makefile": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.4",
+        "friendsofphp/php-cs-fixer": "^3.95.2",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/src/ChecksMinimumSupportedVersion.php
+++ b/src/ChecksMinimumSupportedVersion.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 interface ChecksMinimumSupportedVersion

--- a/src/Coverage/TestLocation.php
+++ b/src/Coverage/TestLocation.php
@@ -41,8 +41,11 @@ final class TestLocation
 
     private ?float $executionTime;
 
-    public function __construct(string $method, ?string $filePath, ?float $executionTime)
-    {
+    public function __construct(
+        string $method,
+        ?string $filePath,
+        ?float $executionTime,
+    ) {
         $this->method = $method;
         $this->filePath = $filePath;
         $this->executionTime = $executionTime;

--- a/src/Coverage/TestLocation.php
+++ b/src/Coverage/TestLocation.php
@@ -31,14 +31,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework\Coverage;
 
 final class TestLocation
 {
     private string $method;
+
     private ?string $filePath;
+
     private ?float $executionTime;
 
     public function __construct(string $method, ?string $filePath, ?float $executionTime)

--- a/src/InvalidVersion.php
+++ b/src/InvalidVersion.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use UnexpectedValueException;

--- a/src/MemoryUsageAware.php
+++ b/src/MemoryUsageAware.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 interface MemoryUsageAware

--- a/src/SyntaxErrorAware.php
+++ b/src/SyntaxErrorAware.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 interface SyntaxErrorAware

--- a/src/TestFrameworkAdapter.php
+++ b/src/TestFrameworkAdapter.php
@@ -48,7 +48,11 @@ interface TestFrameworkAdapter
      *
      * @return string[]
      */
-    public function getInitialTestRunCommandLine(string $extraOptions, array $phpExtraArgs, bool $skipCoverage): array;
+    public function getInitialTestRunCommandLine(
+        string $extraOptions,
+        array $phpExtraArgs,
+        bool $skipCoverage,
+    ): array;
 
     /**
      * @param TestLocation[] $coverageTests

--- a/src/TestFrameworkAdapter.php
+++ b/src/TestFrameworkAdapter.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
@@ -62,7 +60,7 @@ interface TestFrameworkAdapter
         string $mutatedFilePath,
         string $mutationHash,
         string $mutationOriginalFilePath,
-        string $extraOptions
+        string $extraOptions,
     ): array;
 
     /**

--- a/src/TestFrameworkAdapterFactory.php
+++ b/src/TestFrameworkAdapterFactory.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 interface TestFrameworkAdapterFactory
@@ -45,7 +43,7 @@ interface TestFrameworkAdapterFactory
         string $jUnitFilePath,
         string $projectDir,
         array $sourceDirectories,
-        bool $skipCoverage
+        bool $skipCoverage,
     ): TestFrameworkAdapter;
 
     public static function getAdapterName(): string;

--- a/src/UnsupportedTestFrameworkVersion.php
+++ b/src/UnsupportedTestFrameworkVersion.php
@@ -41,8 +41,10 @@ final class UnsupportedTestFrameworkVersion extends RuntimeException
 
     private string $minimumSupportedVersion;
 
-    public function __construct(string $detectedVersion, string $minimumSupportedVersion)
-    {
+    public function __construct(
+        string $detectedVersion,
+        string $minimumSupportedVersion,
+    ) {
         parent::__construct();
 
         $this->detectedVersion = $detectedVersion;

--- a/src/UnsupportedTestFrameworkVersion.php
+++ b/src/UnsupportedTestFrameworkVersion.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use RuntimeException;
@@ -40,6 +38,7 @@ use RuntimeException;
 final class UnsupportedTestFrameworkVersion extends RuntimeException
 {
     private string $detectedVersion;
+
     private string $minimumSupportedVersion;
 
     public function __construct(string $detectedVersion, string $minimumSupportedVersion)

--- a/tests/Coverage/TestLocationTest.php
+++ b/tests/Coverage/TestLocationTest.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework\Coverage;
 
 use PHPUnit\Framework\TestCase;
@@ -50,7 +48,7 @@ final class TestLocationTest extends TestCase
             $testLocation,
             'mutatesNode',
             null,
-            null
+            null,
         );
     }
 
@@ -62,7 +60,7 @@ final class TestLocationTest extends TestCase
             $testLocation,
             'mutatesNode',
             'path/to/Test.php',
-            0.123
+            0.123,
         );
     }
 
@@ -70,7 +68,7 @@ final class TestLocationTest extends TestCase
         TestLocation $testLocation,
         string $expectedMethod,
         ?string $expectedFilePath,
-        ?float $expectedExecutionTime
+        ?float $expectedExecutionTime,
     ): void {
         $this->assertSame($expectedMethod, $testLocation->getMethod());
         $this->assertSame($expectedFilePath, $testLocation->getFilePath());

--- a/tests/InvalidVersionTest.php
+++ b/tests/InvalidVersionTest.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use Error;

--- a/tests/MakefileTest.php
+++ b/tests/MakefileTest.php
@@ -32,8 +32,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use Fidry\Makefile\Test\BaseMakefileTestCase;

--- a/tests/UnsupportedTestFrameworkVersionTest.php
+++ b/tests/UnsupportedTestFrameworkVersionTest.php
@@ -31,8 +31,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 namespace Infection\AbstractTestFramework;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR:

- Updates PHP-CS-Fixer from 3.4 to 3.95.2.
- Moves PHP-CS-Fixer to its own make commands.
- Adjust the configuration of PHP-CS-Fixer to be aligned with the infection main repository configuration.
- Apply PHP-CS-Fixer.