### PR TITLE
chore: Upgrade to PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ergebnis/composer-normalize": "^2.18",
         "fidry/makefile": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.95.2",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^12.0",
         "rector/rector": "^2.4.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ergebnis/composer-normalize": "^2.18",
         "fidry/makefile": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.95.2",
-        "phpunit/phpunit": "^12.0",
+        "phpunit/phpunit": "^12.0 || ^13.0",
         "rector/rector": "^2.4.5"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,19 +7,17 @@
          executionOrder="random"
          failOnWarning="true"
          failOnRisky="true"
-         verbose="true"
+         cacheDirectory=".phpunit.cache"
 >
-
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
-
+        </include>
+    </source>
 </phpunit>

--- a/tests/Coverage/TestLocationTest.php
+++ b/tests/Coverage/TestLocationTest.php
@@ -33,11 +33,10 @@
 
 namespace Infection\AbstractTestFramework\Coverage;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\AbstractTestFramework\Coverage\TestLocation
- */
+#[CoversClass(TestLocation::class)]
 final class TestLocationTest extends TestCase
 {
     public function test_it_can_be_instantiated_for_a_method(): void

--- a/tests/InvalidVersionTest.php
+++ b/tests/InvalidVersionTest.php
@@ -34,11 +34,10 @@
 namespace Infection\AbstractTestFramework;
 
 use Error;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\AbstractTestFramework\InvalidVersion
- */
+#[CoversClass(InvalidVersion::class)]
 final class InvalidVersionTest extends TestCase
 {
     public function test_it_can_be_instantiated(): void

--- a/tests/MakefileTest.php
+++ b/tests/MakefileTest.php
@@ -35,7 +35,9 @@
 namespace Infection\AbstractTestFramework;
 
 use Fidry\Makefile\Test\BaseMakefileTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 final class MakefileTest extends BaseMakefileTestCase
 {
     protected static function getMakefilePath(): string

--- a/tests/UnsupportedTestFrameworkVersionTest.php
+++ b/tests/UnsupportedTestFrameworkVersionTest.php
@@ -33,11 +33,10 @@
 
 namespace Infection\AbstractTestFramework;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\AbstractTestFramework\UnsupportedTestFrameworkVersion
- */
+#[CoversClass(UnsupportedTestFrameworkVersion::class)]
 final class UnsupportedTestFrameworkVersionTest extends TestCase
 {
     public function test_it_can_be_instantiated(): void


### PR DESCRIPTION
- Upgrade to PHPUnit 12 which requires PHP 8.3 (our minimal supported version).
- Allow PHPUnit 13 (will be used on the PHP 8.4 and 8.5 builds).